### PR TITLE
Improve gallery layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     body {
       margin: 0;
       padding: 0;
-      background: linear-gradient(to bottom, #f5e7d0, #e3c9a2);
+      background: url('background.png') center center / cover no-repeat fixed;
       color: #e2d8c3;
       font-family: 'Courier New', monospace;
       display: flex;
@@ -64,6 +64,11 @@
     }
     .enter-image:hover {
       transform: scale(1.05);
+    }
+    img:hover {
+      transform: scale(1.05);
+      filter: brightness(1.2);
+      transition: transform 0.3s ease, filter 0.3s ease;
     }
     .fade-out {
       animation: fadeOut 0.5s ease forwards;

--- a/loading.html
+++ b/loading.html
@@ -9,7 +9,12 @@
     body {
       margin: 0;
       padding: 0;
-      background: linear-gradient(to bottom, #f5e7d0, #e3c9a2);
+      background: url('background.png') center center / cover no-repeat fixed;
+img:hover {
+  transform: scale(1.05);
+  filter: brightness(1.2);
+  transition: transform 0.3s ease, filter 0.3s ease;
+}
       display: flex;
       align-items: center;
       justify-content: center;
@@ -41,7 +46,7 @@
     }
   </style>
 </head>
-<body style="background: linear-gradient(to bottom, #f5e7d0, #e3c9a2); transition: opacity 1s;">
+<body style="background: url('background.png') center center / cover no-repeat fixed; transition: opacity 1s;">
   <div class="loading-wrapper">
     <img src="loading_image.png" alt="Loading...">
   </div>

--- a/next.html
+++ b/next.html
@@ -10,12 +10,17 @@
       cursor: url('frak-cursor.png'), auto;
       margin: 0;
       padding: 0;
-      background: linear-gradient(to bottom, #f5e7d0, #e3c9a2);
+      background: url('background.png') center center / cover no-repeat fixed;
       color: #e2d8c3;
       font-family: 'Courier New', monospace;
       overflow-x: hidden;
     }
 
+img:hover {
+  transform: scale(1.05);
+  filter: brightness(1.2);
+  transition: transform 0.3s ease, filter 0.3s ease;
+}
     .audio-control {
       position: fixed;
       top: 20px;
@@ -30,155 +35,70 @@
 
     .gallery {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      grid-template-columns: repeat(5, 1fr);
       gap: 20px;
-      padding: 100px 40px 40px;
-      max-width: 1400px;
-      margin: 0 auto;
+      padding: 20px;
+      justify-items: center;
     }
-
-    .card {
-      backdrop-filter: blur(12px);
-      background: linear-gradient(to bottom, #f5e7d0, #e3c9a2);
-      border-radius: 20px;
-      overflow: hidden;
-      box-shadow: 0 6px 25px rgba(0, 0, 0, 0.4);
-      border: 1px solid rgba(255, 236, 210, 0.15);
-      transition: transform 0.3s ease, box-shadow 0.3s ease;
+    .gallery-item {
+      position: relative;
     }
-
-    .card:hover {
-      transform: scale(1.02);
-      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
-    }
-
-    .card img {
+    .gallery-item img {
       width: 100%;
-      display: block;
-      cursor: pointer;
+      border-radius: 8px;
+    }
+    .reveal {
+      opacity: 0;
+      transform: translateY(40px);
+      transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+    }
+    .reveal.visible {
+      opacity: 1;
+      transform: none;
     }
 
-    .token-info {
-      max-width: 1000px;
-      background-image: url('file-000000006c2061f79144ae2468ff325a');
-      background-size: cover;
-      background-position: center;
-      color: #f4ead3;
-      padding: 30px;
-      border-radius: 16px;
-      max-width: 800px;
-      margin: 60px auto;
-      box-shadow: 0 4px 30px rgba(0, 0, 0, 0.4);
-      font-family: 'Courier New', monospace;
-    }
 
-    .token-info h2 {
-      margin-top: 0;
-      font-size: 1.8rem;
-    }
-
-    .copy-btn {
-      background: linear-gradient(to bottom, #f5e7d0, #e3c9a2);
-      border: 1px solid #e2d8c3;
-      color: #e2d8c3;
-      padding: 6px 10px;
-      margin-left: 10px;
-      cursor: pointer;
-      font-size: 0.85rem;
-      border-radius: 6px;
-      transition: background 0.3s ease;
-    }
-
-    .copy-btn:hover {
-      background: linear-gradient(to bottom, #f5e7d0, #e3c9a2);
-    }
-
-    @media (max-width: 768px) {
-      .gallery {
-        padding: 80px 20px;
-      }
-
-      .token-info {
-      max-width: 1000px;
-        padding: 20px;
-      }
-    }
-  
-@media (max-width: 768px) {
-  .token-info {
-      max-width: 1000px;
-    position: relative !important;
-    width: 100% !important;
-    max-width: none !important;
-    margin: 40px auto;
-  }
-  .token-info img {
-      max-width: none;
-      width: 100%;
-      height: auto;
-    width: 100%;
-    height: auto;
-    display: block;
-  }
-  .token-text {
-    position: absolute !important;
-    top: 20%;
-    left: 8%;
-    transform: translateY(-50%);
-    width: 80%;
-    font-size: 1rem;
-    text-align: left;
-    z-index: 2;
-  }
-}
-
-    .card {
+    .gallery-item {
       position: relative;
     }
     .download-btn {
       position: absolute;
-      bottom: 8px;
-      right: 8px;
-      background: linear-gradient(to bottom, #f5e7d0, #e3c9a2);
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(0, 0, 0, 0.7);
       color: #fff;
-      padding: 6px 10px;
-      font-size: 0.75rem;
-      text-decoration: none;
-      border-radius: 4px;
+      padding: 6px 12px;
+      border-radius: 6px;
       opacity: 0;
       transition: opacity 0.3s ease;
+      text-decoration: none;
     }
-    .card:hover .download-btn {
+    .gallery-item:hover .download-btn {
       opacity: 1;
     }
 
 @media (max-width: 768px) {
   .gallery {
     grid-template-columns: repeat(2, 1fr);
-    padding: 0 20px 40px;
   }
 }
 </style>
 
 <style>
   .custom-token-box {
-    width: 90%;
-    max-width: 600px;
-    margin: 40px auto;
-    padding: 25px 30px;
-    border-radius: 20px;
-    background: #b88c4a;
-    color: #3a260f;
-    font-family: monospace;
-    font-size: 1.1rem;
+    background: #dbc6a4;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    border-radius: 14px;
+    padding: 15px 20px;
+    max-width: 320px;
+    margin: 20px auto;
     text-align: center;
-    box-shadow: 0 0 10px rgba(100, 60, 20, 0.3);
   }
-</style>
 
 </head>
 <body><img alt="Frak Logo" src="frak-logo.png" style="display:block; margin:30px auto 10px; width: 180px;"/><img alt="Frak Portrait" class="header-image reveal" src="file-9QEUnJmsxxo4gT39mrgCDf" style="display: block; margin: 60px auto; max-width: 700px; border: 6px solid #8a6c3e; border-radius: 20px; box-shadow: 0 6px 20px rgba(0,0,0,0.4);"/>
-<div class="token-info">
+<div class="custom-token-box">
 <h2>Token Info</h2>
 <p><strong>Name:</strong> Frak</p>
 <p><strong>Ticker:</strong> FRAK</p>
@@ -186,35 +106,43 @@
 <p><strong>Supply:</strong> 1,000,000,000</p>
 <p>
 <strong>CA:</strong>
-<span id="ca-text">So1anaFakeAddress123456789</span>
-<button class="copy-btn" onclick="copyCA()">Copy</button>
+<span style="display: inline-flex; align-items: center;">
+  <span id="ca-text">So1anaFakeAddress123456789</span>
+  <button onclick="copyCA()" style="margin-left: 8px;">Copy</button>
+</span>
 </p>
-</div><div class="token-buttons" style="display: flex; justify-content: center; gap: 20px; margin-top: 20px;"><a href="https://x.com/frakwtf" target="_blank"><img alt="X Button" src="btn-x.png" style="width: 120px;"/></a><a href="https://pump.fun" target="_blank"><img alt="Buy Button" src="btn-buy.png" style="width: 120px;"/></a></div><div class="gallery-title reveal" style="text-align: center; font-size: 1.6rem; font-weight: bold; margin: 60px auto 20px;">Frak Gallery</div><div class="gallery">
-<div class="card"><img download="" src="gallery1.png"/><a class="download-btn" download="True" href="gallery1.png">Download</a></div>
-<div class="card"><img download="" src="gallery2.png"/><a class="download-btn" download="True" href="gallery2.png">Download</a></div>
-<div class="card"><img download="" src="gallery3.png"/><a class="download-btn" download="True" href="gallery3.png">Download</a></div>
-<div class="card"><img download="" src="gallery4.png"/><a class="download-btn" download="True" href="gallery4.png">Download</a></div>
-<div class="card"><img download="" src="gallery5.png"/><a class="download-btn" download="True" href="gallery5.png">Download</a></div>
-<div class="card"><img download="" src="gallery6.png"/><a class="download-btn" download="True" href="gallery6.png">Download</a></div>
-<div class="card"><img download="" src="gallery7.png"/><a class="download-btn" download="True" href="gallery7.png">Download</a></div>
-<div class="card"><img download="" src="gallery8.png"/><a class="download-btn" download="True" href="gallery8.png">Download</a></div>
-<div class="card"><img download="" src="gallery9.png"/><a class="download-btn" download="True" href="gallery9.png">Download</a></div>
-<div class="card"><img download="" src="gallery10.png"/><a class="download-btn" download="True" href="gallery10.png">Download</a></div>
-<div class="card"><img download="" src="gallery11.png"/><a class="download-btn" download="True" href="gallery11.png">Download</a></div>
-<div class="card"><img download="" src="gallery12.png"/><a class="download-btn" download="True" href="gallery12.png">Download</a></div>
-<div class="card"><img download="" src="gallery13.png"/><a class="download-btn" download="True" href="gallery13.png">Download</a></div>
-<div class="card"><img download="" src="gallery14.png"/><a class="download-btn" download="True" href="gallery14.png">Download</a></div>
-<div class="card"><img download="" src="gallery15.png"/><a class="download-btn" download="True" href="gallery15.png">Download</a></div>
-<div class="card"><img download="" src="gallery16.png"/><a class="download-btn" download="True" href="gallery16.png">Download</a></div>
-<div class="card"><img download="" src="gallery17.png"/><a class="download-btn" download="True" href="gallery17.png">Download</a></div>
-<div class="card"><img download="" src="gallery18.png"/><a class="download-btn" download="True" href="gallery18.png">Download</a></div>
-<div class="card"><img download="" src="gallery19.png"/><a class="download-btn" download="True" href="gallery19.png">Download</a></div>
-<div class="card"><img download="" src="gallery20.png"/><a class="download-btn" download="True" href="gallery20.png">Download</a></div>
+</div><div class="token-buttons" style="display: flex; justify-content: center; gap: 20px; margin-top: 20px;"><a href="https://x.com/frakwtf" target="_blank"><img alt="X Button" src="btn-x.png" style="width: 120px; cursor: pointer;"/></a><a href="https://pump.fun" target="_blank"><img alt="Buy Button" src="btn-buy.png" style="width: 120px; cursor: pointer;"/></a></div><div class="gallery-title reveal" style="text-align: center; font-size: 1.6rem; font-weight: bold; margin: 60px auto 20px;">Frak Gallery</div><div class="gallery">
+<div class="gallery-item reveal"><img src="gallery1.png"/><a class="download-btn" href="gallery1.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery2.png"/><a class="download-btn" href="gallery2.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery3.png"/><a class="download-btn" href="gallery3.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery4.png"/><a class="download-btn" href="gallery4.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery5.png"/><a class="download-btn" href="gallery5.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery6.png"/><a class="download-btn" href="gallery6.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery7.png"/><a class="download-btn" href="gallery7.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery8.png"/><a class="download-btn" href="gallery8.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery9.png"/><a class="download-btn" href="gallery9.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery10.png"/><a class="download-btn" href="gallery10.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery11.png"/><a class="download-btn" href="gallery11.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery12.png"/><a class="download-btn" href="gallery12.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery13.png"/><a class="download-btn" href="gallery13.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery14.png"/><a class="download-btn" href="gallery14.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery15.png"/><a class="download-btn" href="gallery15.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery16.png"/><a class="download-btn" href="gallery16.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery17.png"/><a class="download-btn" href="gallery17.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery18.png"/><a class="download-btn" href="gallery18.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery19.png"/><a class="download-btn" href="gallery19.png">⬇</a></div>
+<div class="gallery-item reveal"><img src="gallery20.png"/><a class="download-btn" href="gallery20.png">⬇</a></div>
 </div>
 
 
 <audio id="bg-music" src="Frak.mp3"></audio>
 <script>
+function copyCA() {
+  const ca = document.getElementById("ca-text").innerText;
+  navigator.clipboard.writeText(ca).then(() => {
+    alert("CA copied to clipboard!");
+  });
+}
   window.addEventListener("DOMContentLoaded", function () {
     var audio = document.getElementById("bg-music");
     setTimeout(() => {
@@ -299,6 +227,16 @@
 
     updateButtons();
   });
+</script>
+<script>
+window.addEventListener("scroll", () => {
+  document.querySelectorAll(".reveal").forEach(el => {
+    const rect = el.getBoundingClientRect();
+    if (rect.top < window.innerHeight - 50) {
+      el.classList.add("visible");
+    }
+  });
+});
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- unify background across pages and add custom cursor
- show download buttons on hover in a responsive gallery
- add reveal on scroll effect and CA copy helper
- restyle token info box

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68520bd32370832bb932706d9acb2ee1